### PR TITLE
cfulnecky/ut 1010 notification updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+<a name="1.0.10"></a>
+## [1.0.10](https://github.com/HBOCodeLabs/minimal-react-redux-notify/compare/v1.0.9...v1.0.10) (2016-12-06)
+
+
+
 <a name="1.0.9"></a>
 ## [1.0.9](https://github.com/HBOCodeLabs/minimal-react-redux-notify/compare/v1.0.7...v1.0.9) (2016-12-05)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minimal-react-redux-notify",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "Syntactic Sugar providing a minimal fixed set of notification styles from react-redux-notify.",
   "main": "./lib/index.js",
   "files": [

--- a/src/index.js
+++ b/src/index.js
@@ -11,8 +11,23 @@ import notifyReducer from 'react-redux-notify';
 const ICONS = {
     [NOTIFICATION_TYPE_ERROR]: <i className="material-icons">error</i>,
     [NOTIFICATION_TYPE_INFO]: <i className="material-icons">info</i>,
-    [NOTIFICATION_TYPE_SUCCESS]: <i className="material-icons">thumb_up</i>,
+    [NOTIFICATION_TYPE_SUCCESS]: <i className="material-icons">check_circle</i>,
     [NOTIFICATION_TYPE_WARNING]: <i className="material-icons">warning</i>
+};
+
+const styles = {
+    [NOTIFICATION_TYPE_ERROR]: {
+        'notification--error': 'tools-notification tools-notification--error'
+    },
+    [NOTIFICATION_TYPE_INFO]: {
+        'notification--info': 'tools-notification tools-notification--info'
+    },
+    [NOTIFICATION_TYPE_SUCCESS]: {
+        'notification--success': 'tools-notification tools-notification--success'
+    },
+    [NOTIFICATION_TYPE_WARNING]: {
+        'notification--warning': 'tools-notification tools-notification--warning'
+    }
 };
 
 const NEW_NOTIFICATION = 'NEW_NOTIFICATION';
@@ -20,19 +35,21 @@ const NEW_NOTIFICATION = 'NEW_NOTIFICATION';
 const newNotification = (notifyType, message) => ({
     type: NEW_NOTIFICATION,
     payload: {
-        type: notifyType,
-        message: message
+        customStyles: styles[notifyType],
+        message: message,
+        type: notifyType
     }
 });
 
 const notificationEpic = action$ =>
     action$.ofType(NEW_NOTIFICATION)
         .map(action => createNotification({
-            message: action.payload.message,
-            type: action.payload.type,
-            icon: ICONS[action.payload.type],
             canDismiss: true,
-            duration: action.payload.type === NOTIFICATION_TYPE_ERROR ? 0 : 5000
+            customStyles: action.payload.customStyles,
+            duration: action.payload.type === NOTIFICATION_TYPE_ERROR ? 0 : 5000,
+            icon: ICONS[action.payload.type],
+            message: action.payload.message,
+            type: action.payload.type
         }));
 
 export {


### PR DESCRIPTION
Added styles to override react-redux-notify defaults.

This is the second of a 3-part commit and will require the updates from https://github.com/HBOCodeLabs/Tools-Common-Styles/pull/3

Centering the notification requires changes to the root.jsx file in all projects that need it. Toolshed will be the first example.